### PR TITLE
Update dependencies for Python script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 appdirs==1.4.4
-atomicwrites==1.4.0
+atomicwrites==1.3.0
 attrs==21.2.0
 black==21.10b0
 certifi==2021.10.8
@@ -7,11 +7,11 @@ cffi==1.15.0
 chardet==4.0.0
 click==8.0.3
 cryptography==35.0.0
-fpyutils==2.0.1
+fpyutils==1.1.0
 github3.py==3.0.0
 idna==3.3
 jwcrypto==1.0
-md-toc==8.0.1
+md-toc==7.0.1
 pathspec==0.9.0
 pycparser==2.21
 python-dateutil==2.8.2


### PR DESCRIPTION
Modules changed:
- atomicwrites 1.4.0 -> 1.3.0
- fpyutils 2.0.1 -> 1.1.0
- md-toc 8.0.1 -> 7.0.1
This is based on current working versions for [Training](https://github.com/Surya-Training/Training) repo